### PR TITLE
Set 'dots' as the default grid appearance

### DIFF
--- a/app/content/pencil/canvasHelper/canvasImpl.js
+++ b/app/content/pencil/canvasHelper/canvasImpl.js
@@ -1,5 +1,5 @@
-
 var CanvasImpl = {};
+
 CanvasImpl.setupGrid = function () {
     if (this.gridContainer) {
         Dom.empty(this.gridContainer);

--- a/app/content/pencil/canvasHelper/canvasImpl.js
+++ b/app/content/pencil/canvasHelper/canvasImpl.js
@@ -1,5 +1,5 @@
-var CanvasImpl = {};
 
+var CanvasImpl = {};
 CanvasImpl.setupGrid = function () {
     if (this.gridContainer) {
         Dom.empty(this.gridContainer);
@@ -19,14 +19,14 @@ CanvasImpl.setupGrid = function () {
             var z = this.zoom ? this.zoom : 1;
             
             if (Config.get("edit.gridAppearance") === 'dots') {
-            for (var i = 1; i < this.width * z; i += grid.w * z) {
-                var line = document.createElementNS(PencilNamespaces.svg, "svg:line");
-                line.setAttribute("x1", i);
-                line.setAttribute("y1", 0);
-                line.setAttribute("x2", i);
-                line.setAttribute("y2", this.height * z);
-                line.setAttribute("style", "stroke-dasharray: 1," + (grid.h - 1) * z + ";");
-                this.gridContainer.appendChild(line);
+                for (var i = 1; i < this.width * z; i += grid.w * z) {
+                    var line = document.createElementNS(PencilNamespaces.svg, "svg:line");
+                    line.setAttribute("x1", i);
+                    line.setAttribute("y1", 0);
+                    line.setAttribute("x2", i);
+                    line.setAttribute("y2", this.height * z);
+                    line.setAttribute("style", "stroke-dasharray: 1," + (grid.h - 1) * z + ";");
+                    this.gridContainer.appendChild(line);
                 }
             } else {
                 for (var i = 1; i < this.width * z; i += grid.w * z) {

--- a/app/defaults/preferences/pencil.js
+++ b/app/defaults/preferences/pencil.js
@@ -1,5 +1,6 @@
 pref("pencil.config.grid.enabled", true);
 pref("pencil.config.edit.gridSize", 8);
+pref("pencil.config.edit.gridAppearance", "dots");
 pref("pencil.config.edit.snap.grid", false);
 pref("pencil.config.object.snapping.enabled", true);
 pref("pencil.config.object.snapping.background", true);


### PR DESCRIPTION
I really like your addition of the `'lines'` grid appearance. The dots were always had to see, especially when zoomed in. 

When I tried out your change, I noticed there wasn't a default for grid appearance, so I set it to `'dots'` to preserve the previous look. I also fixed a minor indentation issue.
